### PR TITLE
Removed depdendency on git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cookiecutter
 qpm
 click
 pyyaml
+giturlparse.py

--- a/shellfoundry/commands/new_command.py
+++ b/shellfoundry/commands/new_command.py
@@ -1,14 +1,15 @@
 import os
-
 import click
 from cookiecutter.main import cookiecutter
-
+from shellfoundry.utilities.repository_downloader import RepositoryDownloader
+from shellfoundry.utilities.temp_dir_context import TempDirContext
 from shellfoundry.utilities.template_retriever import TemplateRetriever
 
 
 class NewCommandExecutor(object):
-    def __init__(self, template_retriever=None):
+    def __init__(self, template_retriever=None, repository_downloader=None):
         self.template_retriever = template_retriever or TemplateRetriever()
+        self.repository_downloader = repository_downloader or RepositoryDownloader()
 
     def new(self, name, template):
         """
@@ -17,24 +18,27 @@ class NewCommandExecutor(object):
         :param template:
         """
         templates = self.template_retriever.get_templates()
-
         if template not in templates:
             raise click.BadParameter(
                 u'Template {0} does not exist. Supported templates are: {1}'.format(template,
                                                                                     self._get_templates_with_comma(
-                                                                                    templates)))
+                                                                                        templates)))
         template_obj = templates[template]
 
-        # Supports creating shell in the same directory
-        if name == '.':
-            template_obj.params['project_name'] = os.path.split(os.getcwd())[1]
-            cookiecutter(template_obj.repository, no_input=True,
-                         extra_context= template_obj.params,
-                         overwrite_if_exists=True, output_dir='..')
-        else:
-            template_obj.params['project_name'] = name
-            cookiecutter(template_obj.repository, no_input=True,
-                         extra_context=template_obj.params)
+        with TempDirContext(name) as temp_dir:
+
+            repo_path = self.repository_downloader.download_template(temp_dir, template_obj.repository)
+            # Supports creating shell in the same directory
+            if name == '.':
+                template_obj.params['project_name'] = os.path.split(os.getcwd())[1]
+                cookiecutter(repo_path, no_input=True,
+                             extra_context=template_obj.params,
+                             overwrite_if_exists=True, output_dir='..')
+            else:
+                print name
+                template_obj.params['project_name'] = name
+                cookiecutter(repo_path, no_input=True,
+                             extra_context=template_obj.params)
 
     @staticmethod
     def _get_templates_with_comma(templates):

--- a/shellfoundry/utilities/repository_downloader.py
+++ b/shellfoundry/utilities/repository_downloader.py
@@ -1,0 +1,87 @@
+import os
+import zipfile
+import requests
+from giturlparse import parse
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+
+class DownloadedRepoExtractor:
+    def __init__(self):
+        pass
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def extract_to_folder(self, repo_link, folder):
+        pass
+
+
+class ZipDownloadedRepoExtractor (DownloadedRepoExtractor):
+
+    def extract_to_folder(self, repo_link, folder):
+        with zipfile.ZipFile(repo_link, "r") as z:
+            infos = z.infolist()
+            z.extractall(folder)
+        return [info.filename for info in infos]
+
+
+class RepositoryDownloader:
+    def __init__(self, repo_extractor=ZipDownloadedRepoExtractor()):
+        self.repo_extractor = repo_extractor
+
+    def download_template(self, target_dir, repo_address):
+        user, repo = self._parse_repo_url(repo_address)
+        download_url = self._join_url_all("https://api.github.com/repos", [user, repo, 'zipball', 'master'])
+        archive_path = ''
+        try:
+            archive_path = self._download_file(download_url, target_dir)
+
+            repo_content = self.repo_extractor.extract_to_folder(archive_path, target_dir)
+
+            # The first entry is always the root folder by git zipball convention
+            root_dir = repo_content[0]
+
+            return os.path.join(target_dir, root_dir)
+
+        finally:
+            if os.path.exists(archive_path):
+                os.remove(archive_path)
+
+    def _join_url_all(self, url, fragments):
+        for frag in fragments:
+            url = url + '/' + frag
+        return url
+
+    def _try_parse_git_url(self, url):
+        if url.startswith('git@'):
+            parsed_repo = parse(url)
+            return True, parsed_repo.owner, parsed_repo.repo
+        else:
+            return False, None, None
+
+    def _try_parse_http_url(self, url):
+        if url.startswith('http'):
+            fragments = url.split("/")
+            return True, fragments[-2], fragments[-1]
+        else:
+            return False, None, None
+
+    def _parse_repo_url(self, url):
+        success, user, repo = self._try_parse_git_url(url)
+        if not success:
+            success, user, repo = self._try_parse_http_url(url)
+
+        return user, repo
+
+    def _download_file(self, url, directory):
+        local_filename = os.path.join(directory, url.split('/')[-1])
+        # NOTE the stream=True parameter
+        r = requests.get(url, stream=True)
+        with open(local_filename, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+                    # f.flush() commented by recommendation from J.F.Sebastian
+        return local_filename

--- a/shellfoundry/utilities/temp_dir_context.py
+++ b/shellfoundry/utilities/temp_dir_context.py
@@ -1,0 +1,16 @@
+import tempfile
+import shutil
+
+
+class TempDirContext:
+
+    def __init__(self, prefix =''):
+        self.temp_dir = None
+        self.prefix=prefix
+
+    def __enter__(self):
+        self.temp_dir = tempfile.mkdtemp(prefix=self.prefix)
+        return self.temp_dir
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        shutil.rmtree(self.temp_dir,ignore_errors=True)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 mock
 pyfakefs
+httpretty

--- a/tests/test_commands/test_new_command.py
+++ b/tests/test_commands/test_new_command.py
@@ -22,13 +22,17 @@ class TestMainCli(fake_filesystem_unittest.TestCase):
     def test_cookiecutter_called_for_existing_template(self, mock_cookiecutter):
         # Arrange
         template_retriever = Mock()
-        template_retriever.get_templates = Mock(return_value={'base': ShellTemplate('base', '', 'url')})
-        command_executor = NewCommandExecutor(template_retriever=template_retriever)
+        template_retriever.get_templates = Mock(return_value={'base': ShellTemplate('base', '', 'https://fakegithub.com/user/repo')})
+
+        repo_downloader = Mock()
+        repo_downloader.download_template.return_value = 'repo_path'
+
+        command_executor = NewCommandExecutor(template_retriever=template_retriever, repository_downloader=repo_downloader)
         # Act
         command_executor.new('nut_shell', 'base')
 
         # Assert
-        mock_cookiecutter.assert_called_once_with('url', no_input=True, extra_context={u'project_name': 'nut_shell'})    \
+        mock_cookiecutter.assert_called_once_with('repo_path', no_input=True, extra_context={u'project_name': 'nut_shell'})    \
 
 
     @patch('shellfoundry.commands.new_command.cookiecutter')
@@ -36,7 +40,11 @@ class TestMainCli(fake_filesystem_unittest.TestCase):
         # Arrange
         template_retriever = Mock()
         template_retriever.get_templates = Mock(return_value={'base': ShellTemplate('base', '', 'url')})
-        command_executor = NewCommandExecutor(template_retriever=template_retriever)
+
+        repo_downloader = Mock()
+        repo_downloader.download_template.return_value = 'repo_path'
+
+        command_executor = NewCommandExecutor(template_retriever=template_retriever,  repository_downloader=repo_downloader)
 
         self.fs.CreateDirectory('linux-shell')
         os.chdir('linux-shell')
@@ -45,7 +53,7 @@ class TestMainCli(fake_filesystem_unittest.TestCase):
         command_executor.new('.', 'base')
 
         # Assert
-        mock_cookiecutter.assert_called_once_with('url',
+        mock_cookiecutter.assert_called_once_with('repo_path',
                                                   no_input=True,
                                                   extra_context={u'project_name': 'linux-shell'},
                                                   overwrite_if_exists=True,

--- a/tests/test_utilities/test_repo_downloader.py
+++ b/tests/test_utilities/test_repo_downloader.py
@@ -1,0 +1,84 @@
+from unittest import TestCase
+import httpretty
+from mock import Mock
+from pyfakefs import fake_filesystem_unittest
+from shellfoundry.utilities.repository_downloader import RepositoryDownloader, DownloadedRepoExtractor
+import requests
+import os
+
+
+class TestRepositoryDownloader(fake_filesystem_unittest.TestCase):
+
+
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_extracts_and_calls_api_url_from_https_addrses(self):
+        httpretty.enable()  # enable HTTPretty so that it will monkey patch the socket module
+        test_dir = '/test_dir'
+        self.fs.CreateDirectory(test_dir)
+
+        input_https_address = "https://api.github.com/org/repo"
+        expected_api_url = "https://api.github.com/repos/org/repo/zipball/master"
+
+        httpretty.register_uri(httpretty.GET, expected_api_url,
+                               body="repo-main/,repo-main/shell.txt,repo-main/datamodel/datamodel.xml", streaming=True, status=200)
+
+        RepositoryDownloader(repo_extractor=TestRepositoryDownloader.FakeExtractor(self.fs)) \
+            .download_template(test_dir, input_https_address)
+
+        self.assertIsNotNone(httpretty.last_request())
+
+
+    def test_extracts_and_calls_api_url_from_git_addrses(self):
+        httpretty.enable()  # enable HTTPretty so that it will monkey patch the socket module
+        test_dir = '/test_dir'
+        self.fs.CreateDirectory(test_dir)
+
+        input_https_address = "git@github.com:org/repo.git"
+        expected_api_url = "https://api.github.com/repos/org/repo/zipball/master"
+
+        httpretty.register_uri(httpretty.GET, expected_api_url,
+                               body="repo-main/,repo-main/shell.txt,repo-main/datamodel/datamodel.xml", streaming=True, status=200)
+
+        RepositoryDownloader(repo_extractor=TestRepositoryDownloader.FakeExtractor(self.fs)) \
+            .download_template(test_dir, input_https_address)
+
+        self.assertIsNotNone(httpretty.last_request())
+
+
+    def test_returns_the_root_folder_of_the_git_repo(self):
+        httpretty.enable()  # enable HTTPretty so that it will monkey patch the socket module
+        test_dir = '/test_dir'
+        self.fs.CreateDirectory(test_dir)
+
+        input_https_address = "git@github.com:org/repo.git"
+        expected_api_url = "https://api.github.com/repos/org/repo/zipball/master"
+
+        httpretty.register_uri(httpretty.GET, expected_api_url,
+                               body="repo-main/,repo-main/shell.txt,repo-main/datamodel/datamodel.xml", streaming=True, status=200)
+
+        result = RepositoryDownloader(repo_extractor=TestRepositoryDownloader.FakeExtractor(self.fs)) \
+            .download_template(test_dir, input_https_address)
+
+        self.assertEqual(result, os.path.join(test_dir, "repo-main/"))
+
+
+    class FakeExtractor(DownloadedRepoExtractor):
+        def __init__(self, fs):
+            super(TestRepositoryDownloader.FakeExtractor, self).__init__()
+            self.fs = fs
+
+        def extract_to_folder(self, repo_link, folder):
+            files = []
+            with open(repo_link, "r") as f:
+                content = f.read().replace('\n', '')
+
+            for file in content.split(','):
+                if file.endswith('/'):
+                    self.fs.CreateDirectory(os.path.join(folder, file))
+                else:
+                    self.fs.CreateFile(os.path.join(folder, file))
+                files.append(file)
+
+            return files


### PR DESCRIPTION
## Description
Instead of cloning using git, ShellFoundry will now download the template repo and extract it, then run CookieCutter

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/50)
<!-- Reviewable:end -->
