### PR TITLE
update rest-api version to 7.2.0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ click
 pyyaml
 giturlparse.py
 cloudshell-automation-api>=7.0.0.0,<7.3.0.0
-cloudshell-rest-api>=7.2.0.6
+cloudshell-rest-api>=7.2.0.7


### PR DESCRIPTION
## Description
cloudshell-rest-api was upgraded with a breaking change: UpdateShell uses PUT method instead of POST

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/83)
<!-- Reviewable:end -->
