### PR TITLE
Display list by window size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cookiecutter
 qpm
 click
 pyyaml
+terminaltables
 giturlparse.py
 cloudshell-automation-api>=7.0.0.0,<7.3.0.0
 cloudshell-rest-api>=7.2.0.7

--- a/shellfoundry/commands/list_command.py
+++ b/shellfoundry/commands/list_command.py
@@ -3,7 +3,8 @@ import textwrap
 
 from requests.exceptions import SSLError
 from shellfoundry.utilities.template_retriever import TemplateRetriever
-
+from terminaltables import AsciiTable
+from textwrap import wrap
 
 class ListCommandExecutor(object):
     def __init__(self, template_retriever=None):
@@ -15,13 +16,19 @@ class ListCommandExecutor(object):
         except SSLError:
             raise click.UsageError('Could not retrieve the templates list. Are you offline?')
 
-        prefixlen = 23
-        output = u'\r\nTemplates:\r\n'
+        template_rows = [['Template Name','Description']]
         for template in templates.values():
-            prefix = ("  " + template.name + " ").ljust(prefixlen)
-            wrapper = textwrap.TextWrapper(initial_indent=prefix, width=77,
-                                           subsequent_indent=' ' * prefixlen)
-            message = template.description
-            output += '\r\n' + wrapper.fill(message)
+            template_rows.append([template.name, '']) #description is added later by column max width
 
+        table = AsciiTable(template_rows)
+        table.outer_border = False
+        table.inner_column_border = False
+        max_width = table.column_max_width(1)
+        row = 1
+        for template in templates.values():
+            wrapped_string = '\n'.join(wrap(template.description, max_width))
+            table.table_data[row][1] = wrapped_string
+            row += 1
+
+        output = table.table
         click.echo(output)

--- a/tests/test_commands/test_list_command.py
+++ b/tests/test_commands/test_list_command.py
@@ -21,8 +21,9 @@ class TestListCommand(unittest.TestCase):
         list_command_executor.list()
 
         # Assert
-        echo_mock.assert_called_once_with(u'\r\nTemplates:\r\n\r\n'
-                                          u'  base                 description')
+        echo_mock.assert_called_once_with(u' Template Name  Description \n'
+                                          u'----------------------------\n'
+                                          u' base           description ')
 
     def test_shows_informative_message_when_offline(self):
         # Arrange
@@ -48,6 +49,31 @@ class TestListCommand(unittest.TestCase):
 
         # Assert
         echo_mock.assert_called_once_with(
-            u'\r\nTemplates:\r\n\r\n'
-            u'  base                 base description\r\n'
-            u'  switch               switch description')
+            u' Template Name  Description        \n'
+            u'-----------------------------------\n'
+            u' base           base description   \n'
+            u' switch         switch description ')
+
+    @patch('click.echo')
+    def test_two_long_named_templates_are_displayed_on_normal_window(self, echo_mock):
+        # Arrange
+        template_retriever = Mock()
+        template_retriever.get_templates = Mock(return_value=OrderedDict(
+            [('tosca/networking/switch', ShellTemplate('tosca/networking/switch', 'TOSCA based template for standard Switch devices/virtual appliances', '')),
+             ('tosca/networking/WirelessController', ShellTemplate('tosca/networking/WirelessController', 'TOSCA based template for standard WirelessController devices/virtual appliances', ''))]))
+
+        list_command_executor = ListCommandExecutor(template_retriever)
+
+        # Act
+        list_command_executor.list()
+
+        # Assert
+        echo_mock.assert_called_once_with(
+            u' Template Name                        Description                              \n'
+            u'-------------------------------------------------------------------------------\n'
+            u' tosca/networking/switch              TOSCA based template for standard Switch \n'
+            u'                                      devices/virtual appliances               \n'
+            u' tosca/networking/WirelessController  TOSCA based template for standard        \n'
+            u'                                      WirelessController devices/virtual       \n'
+            u'                                      appliances                               ')
+


### PR DESCRIPTION
with the new long tosca template names the list was not looking good.
the templates are now in a table, that is created by the window size, having the description wrapping if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/93)
<!-- Reviewable:end -->
