### PR TITLE
Fixed a bug which caused list command tests on travis to suddenly fai…

### DIFF
--- a/shellfoundry/commands/list_command.py
+++ b/shellfoundry/commands/list_command.py
@@ -1,6 +1,7 @@
 import click
 import textwrap
 
+from os import linesep
 from requests.exceptions import SSLError
 from shellfoundry.utilities.template_retriever import TemplateRetriever
 from terminaltables import AsciiTable
@@ -18,15 +19,21 @@ class ListCommandExecutor(object):
 
         template_rows = [['Template Name','Description']]
         for template in templates.values():
-            template_rows.append([template.name, '']) #description is added later by column max width
+            template_rows.append(
+                [template.name, template.description])  # description is later wrapped based on the size of the console
 
         table = AsciiTable(template_rows)
         table.outer_border = False
         table.inner_column_border = False
         max_width = table.column_max_width(1)
+
+        if max_width <= 0: # verify that the console window is not too small, and if so skip the wrapping logic
+            click.echo(table.table)
+            return
+
         row = 1
         for template in templates.values():
-            wrapped_string = '\n'.join(wrap(template.description, max_width))
+            wrapped_string = linesep.join(wrap(template.description, max_width))
             table.table_data[row][1] = wrapped_string
             row += 1
 

--- a/tests/test_commands/test_list_command.py
+++ b/tests/test_commands/test_list_command.py
@@ -1,7 +1,7 @@
 import unittest
 
 from click import UsageError
-from mock import Mock, patch
+from mock import Mock, patch, PropertyMock
 from requests.exceptions import SSLError
 from shellfoundry.commands.list_command import ListCommandExecutor
 from shellfoundry.models.shell_template import ShellTemplate
@@ -10,8 +10,12 @@ from collections import OrderedDict
 
 class TestListCommand(unittest.TestCase):
     @patch('click.echo')
-    def test_single_template_is_displayed(self, echo_mock):
+    @patch('shellfoundry.commands.list_command.AsciiTable.column_max_width')
+    def test_single_template_is_displayed(self, max_width_mock, echo_mock):
         # Arrange
+        max_width_mock.return_value = 62    # mocking the max width to eliminate the distinction
+        # between the running console size
+
         template_retriever = Mock()
         template_retriever.get_templates = Mock(return_value={'base': ShellTemplate('base', 'description', '')})
 
@@ -35,8 +39,12 @@ class TestListCommand(unittest.TestCase):
         self.assertRaisesRegexp(UsageError, "offline", list_command_executor.list)
 
     @patch('click.echo')
-    def test_two_templates_are_displayed(self, echo_mock):
+    @patch('shellfoundry.commands.list_command.AsciiTable.column_max_width')
+    def test_two_templates_are_displayed(self, max_width_mock, echo_mock):
         # Arrange
+        max_width_mock.return_value = 62    # mocking the max width to eliminate the distinction
+        # between the running console size
+
         template_retriever = Mock()
         template_retriever.get_templates = Mock(return_value=OrderedDict(
             [('base', ShellTemplate('base', 'base description', '')),
@@ -55,12 +63,20 @@ class TestListCommand(unittest.TestCase):
             u' switch         switch description ')
 
     @patch('click.echo')
-    def test_two_long_named_templates_are_displayed_on_normal_window(self, echo_mock):
+    @patch('shellfoundry.commands.list_command.AsciiTable.column_max_width')
+    def test_two_long_named_templates_are_displayed_on_normal_window(self, max_width_mock, echo_mock):
         # Arrange
+        max_width_mock.return_value = 40  # mocking the max width to eliminate the distinction
+        # between the running console size
+
         template_retriever = Mock()
         template_retriever.get_templates = Mock(return_value=OrderedDict(
-            [('tosca/networking/switch', ShellTemplate('tosca/networking/switch', 'TOSCA based template for standard Switch devices/virtual appliances', '')),
-             ('tosca/networking/WirelessController', ShellTemplate('tosca/networking/WirelessController', 'TOSCA based template for standard WirelessController devices/virtual appliances', ''))]))
+            [('tosca/networking/switch', ShellTemplate('tosca/networking/switch',
+                                                       'TOSCA based template for standard Switch devices/virtual appliances',
+                                                       '')),
+             ('tosca/networking/WirelessController', ShellTemplate('tosca/networking/WirelessController',
+                                                                   'TOSCA based template for standard WirelessController devices/virtual appliances',
+                                                                   ''))]))
 
         list_command_executor = ListCommandExecutor(template_retriever)
 
@@ -77,3 +93,28 @@ class TestListCommand(unittest.TestCase):
             u'                                      WirelessController devices/virtual       \n'
             u'                                      appliances                               ')
 
+    @patch('click.echo')
+    @patch('shellfoundry.commands.list_command.AsciiTable.column_max_width')
+    def test_console_size_small_description_wrapping_logic_ignored(self, max_width_mock, echo_mock):
+        # Arrange
+        max_width_mock.return_value = 0
+        template_retriever = Mock()
+        template_retriever.get_templates = Mock(return_value=OrderedDict(
+            [('tosca/networking/switch', ShellTemplate('tosca/networking/switch',
+                                                       'TOSCA based template for standard Switch devices/virtual appliances',
+                                                       '')),
+             ('tosca/networking/WirelessController', ShellTemplate('tosca/networking/WirelessController',
+                                                                   'TOSCA based template for standard WirelessController devices/virtual appliances',
+                                                                   ''))]))
+
+        list_command_executor = ListCommandExecutor(template_retriever)
+
+        # Act
+        list_command_executor.list()
+
+        # Assert
+        echo_mock.assert_called_once_with(
+            u' Template Name                        Description                                                                     \n'
+            u'----------------------------------------------------------------------------------------------------------------------\n'
+            u' tosca/networking/switch              TOSCA based template for standard Switch devices/virtual appliances             \n'
+            u' tosca/networking/WirelessController  TOSCA based template for standard WirelessController devices/virtual appliances ')


### PR DESCRIPTION
## Description
Fixed a bug which caused list command tests on travis to suddenly fail due to differentiation between the running console size. The list tests passed with a specific console size boundary, but somehow travis started to run the tests with a smaller console and thus caused the tests to fail.

## Related Stories
List related PRs against other branches:

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/100)
<!-- Reviewable:end -->
