### PR TITLE
ommiting bootstrap.py from coverage utility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [report]
 omit =
     shellfoundry/__main__.py
+    shellfoundry/bootstrap.py


### PR DESCRIPTION
## Description
ommiting bootstrap.py from coverage utility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/164)
<!-- Reviewable:end -->
