### PR TITLE
Renaming traffic-generator-controller-service

### DIFF
--- a/templates_v1.yml
+++ b/templates_v1.yml
@@ -175,7 +175,7 @@ templates:
       description : 2nd generation shell template for a cloud service
       repository : https://github.com/QualiSystems/shellfoundry-tosca-cloud-service-template
       min_cs_ver: 8.3
-    - name : gen2/traffic-generator-controller-service
+    - name : gen2/traffic-generator-controller
       params:
         project_name :
         family_name : TrafficGeneratorController


### PR DESCRIPTION
## Description
Renaming traffic-generator-controller-service to traffic-generator-controller, in order to match the standard name

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/199)
<!-- Reviewable:end -->
