### PR TITLE
Fixing CloudProvider in templates_v1.yaml

### DIFF
--- a/templates_v1.yml
+++ b/templates_v1.yml
@@ -185,7 +185,7 @@ templates:
     - name : gen2/cloud-provider
       params:
         project_name :
-        family_name : CloudProvider
+        family_name :
       description : 2nd generation shell template for a cloud provider
       repository : https://github.com/QualiSystems/shellfoundry-tosca-cloudprovider-template
       min_cs_ver: 9.0


### PR DESCRIPTION
## Description
Removed family_name since it is not required for regular templates.

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/shellfoundry/206)
<!-- Reviewable:end -->
