### PR TITLE
print list of urls to download for offline templates

### DIFF
--- a/shellfoundry/bootstrap.py
+++ b/shellfoundry/bootstrap.py
@@ -35,12 +35,13 @@ def version():
 @click.option(u'--gen1', 'default_view', flag_value=GEN_ONE, help="Show 1st generation shell templates")
 @click.option(u'--layer1', 'default_view', flag_value=LAYER_ONE, help="Show layer1 shell templates")
 @click.option(u'--all', 'default_view', flag_value=NO_FILTER, help="Show all templates")
+@click.option(u'--urls', 'offline_links', flag_value=NO_FILTER, help="Show download links for offline templates")
 @shellfoundry_version_check(abort_if_major=True)
-def list(default_view):
+def list(default_view, offline_links):
     """
     Lists the available shell templates
     """
-    ListCommandExecutor(default_view).list()
+    ListCommandExecutor(default_view, offline_links=offline_links).list()
 
 
 @cli.command()

--- a/shellfoundry/commands/list_command.py
+++ b/shellfoundry/commands/list_command.py
@@ -9,24 +9,37 @@ from terminaltables import AsciiTable
 from textwrap import wrap
 
 from cloudshell.rest.exceptions import FeatureUnavailable
-from shellfoundry import ALTERNATIVE_TEMPLATES_PATH
+from shellfoundry import ALTERNATIVE_TEMPLATES_PATH, ALTERNATIVE_STANDARDS_PATH
 from shellfoundry.utilities.template_retriever import TemplateRetriever, FilteredTemplateRetriever
 from shellfoundry.utilities.config_reader import Configuration, ShellFoundryConfig, CloudShellConfigReader
-from shellfoundry.utilities.standards import Standards
+from shellfoundry.utilities.standards import StandardVersionsFactory, Standards
 from ..exceptions import FatalError
+from shellfoundry.utilities.template_url import construct_template_url
 
 
 class ListCommandExecutor(object):
-    def __init__(self, default_view=None, template_retriever=None, standards=None):
+    def __init__(self, default_view=None, template_retriever=None, standards=None, offline_links=None, standard_versions=None):
         """
+
         :param str default_view:
+        :param template_retriever:
         :param Standards standards:
+        :param offline_links:
+        :param StandardVersions standard_versions:
         """
         dv = default_view or Configuration(ShellFoundryConfig()).read().defaultview
         self.template_retriever = template_retriever or FilteredTemplateRetriever(dv, TemplateRetriever())
         self.show_info_msg = default_view is None
         self.standards = standards or Standards()
+        self.get_offline_links = offline_links is not None
         self.cloudshell_config_reader = Configuration(CloudShellConfigReader())
+        self.standard_versions = standard_versions or StandardVersionsFactory()
+
+    def _get_template_latest_version(self, standards_list, standard):
+        try:
+            return self.standard_versions.create(standards_list).get_latest_version(standard)
+        except Exception as e:
+            click.ClickException(e.message)
 
     def list(self):
         """  """
@@ -47,6 +60,7 @@ class ListCommandExecutor(object):
         except FatalError as err:
             raise click.UsageError(err.message)
         except FeatureUnavailable:
+            standards = self.standards.fetch(alternative=ALTERNATIVE_STANDARDS_PATH)
             if online_mode:
                 templates = self.template_retriever.get_templates(alternative=ALTERNATIVE_TEMPLATES_PATH)
             else:
@@ -56,34 +70,62 @@ class ListCommandExecutor(object):
             raise click.ClickException("No templates matched the view criteria(gen1/gen2) or "
                                        "available templates and standards are not compatible")
 
-        template_rows = [["Template Name", "CloudShell Ver.", "Description"]]
-        for template in templates.values():
-            template = template[0]
-            cs_ver_txt = str(template.min_cs_ver) + " and up"
-            template_rows.append(
-                [template.name, cs_ver_txt,
-                 template.description])  # description is later wrapped based on the size of the console
+        if self.get_offline_links:
+            template_rows = [["Template Name", "Download URL"]]
+            for template in templates.values():
+                template = template[0]
+                version = self._get_template_latest_version(standards, template.standard)
+                url = construct_template_url(template.repository, version)
+                template_rows.append([template.name, url])  # description is later wrapped based on the size of the console
 
-        table = AsciiTable(template_rows)
-        table.outer_border = False
-        table.inner_column_border = False
-        max_width = table.column_max_width(2)
+            table = AsciiTable(template_rows)
+            table.outer_border = False
+            table.inner_column_border = False
+            max_width = table.column_max_width(1)
 
-        if max_width <= 0:  # verify that the console window is not too small, and if so skip the wrapping logic
-            click.echo(table.table)
-            return
+            if max_width <= 0:  # verify that the console window is not too small, and if so skip the wrapping logic
+                click.echo(table.table)
+                return
 
-        row = 1
-        for template in templates.values():
-            template = template[0]
-            wrapped_string = linesep.join(wrap(template.description, max_width))
-            table.table_data[row][2] = wrapped_string
-            row += 1
+            row = 0
+            for template, url in template_rows:
+                if row > 0:
+                    wrapped_string = linesep.join(wrap(url, max_width))
+                    table.table_data[row][1] = wrapped_string
+                row += 1
 
-        output = table.table
-        click.echo(output)
+            output = table.table
+            click.echo(output)
+
+        else:
+            template_rows = [["Template Name", "CloudShell Ver.", "Description"]]
+            for template in templates.values():
+                template = template[0]
+                cs_ver_txt = str(template.min_cs_ver) + " and up"
+                template_rows.append(
+                    [template.name, cs_ver_txt,
+                     template.description])  # description is later wrapped based on the size of the console
+
+            table = AsciiTable(template_rows)
+            table.outer_border = False
+            table.inner_column_border = False
+            max_width = table.column_max_width(2)
+
+            if max_width <= 0:  # verify that the console window is not too small, and if so skip the wrapping logic
+                click.echo(table.table)
+                return
+
+            row = 1
+            for template in templates.values():
+                template = template[0]
+                wrapped_string = linesep.join(wrap(template.description, max_width))
+                table.table_data[row][2] = wrapped_string
+                row += 1
+
+            output = table.table
+            click.echo(output)
 
         if self.show_info_msg:
             click.echo("""
-As of CloudShell 8.0, CloudShell uses 2nd generation shells, to view the list of 1st generation shells use: shellfoundry list --gen1.
-For more information, please visit our devguide: https://qualisystems.github.io/devguide/""")
+As of CloudShell 8.0, CloudShell uses 2nd generation shells. To view the list of the 1st generation shells use: shellfoundry list --gen1.
+For more information, please visit our dev guide at: https://devguide.quali.com""")


### PR DESCRIPTION
filtered by the min_cs_version and installed standards

## Description
When a user needs to download the relevant offline templates to use later on, they need to have it filtered by the relevant cloudshell version and the installed standards
usage: shellfoundry list --urls

![image](https://user-images.githubusercontent.com/1122397/46549413-c1f48300-c886-11e8-8282-dfcf4ac1d86c.png)

## Breaking
NO
