### PR TITLE
align 'cookiecutter' version with 'click'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-cookiecutter
+cookiecutter==1.6.0
 click==6.7
 pyyaml
 terminaltables


### PR DESCRIPTION
cookiecutter released a new version a few days ago that uses a new version of 'click'
but here at shellfoundry we use an old version of 'click'

if not aligned, then when creating a new shell e.g.:
'shellfoundry new my-dash-test --template gen2/networking/switch'
it say:
'pkg_resources.ContextualVersionConflict: (click 6.7 (c:\python36\lib\site-packages), Requirement.parse('click>=7.0'), {'cookiecutter'})'


