### PR TITLE
py3 fix for writing out tosca data

### DIFF
--- a/shellfoundry/utilities/modifiers/definition/definition_modification.py
+++ b/shellfoundry/utilities/modifiers/definition/definition_modification.py
@@ -39,7 +39,7 @@ class DefinitionModification(object):
             tosca_data.append("\n{field}: {value}".format(field=field, value=value))
 
         with open(os.path.join(self.shell_path, TOSCA_META_LOCATION), "wb") as tosca_file:
-            tosca_file.writelines(tosca_data)
+            tosca_file.writelines(line.encode("utf-8") for line in tosca_data)
 
     def add_field_to_definition(self, field, value=None, overwrite=False):
         """ Add new field to shell-definition.yaml


### PR DESCRIPTION
fixes:

  File "/home/psherratt/cloudshell/env/lib/python3.6/site-packages/shellfoundry/utilities/modifiers/definition/definition_modification.py", line 42, in edit_tosca_meta
    tosca_file.writelines(tosca_data)
TypeError: a bytes-like object is required, not 'str'

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Stories
List related PRs against other branches:

## Breaking
YES | NO

## Breaking changes
- ### Breaking change description
      Detailed change info 
      Migration steps

