### PR TITLE
adding setuptools as a dependency for python 3.12+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ colorama
 giturlparse.py
 ruamel.yaml
 cryptography
+setuptools; python_version >= '3.12'


### PR DESCRIPTION
## Description
Adding _setuptools_ packages as a requirement for python version >= 3.12

## Related Stories
none
## Breaking
NO

